### PR TITLE
PMM-7144 Reject same cluster name

### DIFF
--- a/service/k8sclient/k8sclient.go
+++ b/service/k8sclient/k8sclient.go
@@ -356,7 +356,7 @@ func (c *K8sClient) CreateXtraDBCluster(ctx context.Context, params *XtraDBParam
 	}
 
 	var secret common.Secret
-	err := c.kubeCtl.Get(ctx, k8sMetaKindSecret, defaultPXCSecretName, &secret)
+	err = c.kubeCtl.Get(ctx, k8sMetaKindSecret, defaultPXCSecretName, &secret)
 	if err != nil {
 		return errors.Wrap(err, "cannot get default PXC secrets")
 	}
@@ -730,7 +730,7 @@ func (c *K8sClient) CreatePSMDBCluster(ctx context.Context, params *PSMDBParams)
 	}
 
 	var secret common.Secret
-	err := c.kubeCtl.Get(ctx, k8sMetaKindSecret, defaultPSMDBSecretName, &secret)
+	err = c.kubeCtl.Get(ctx, k8sMetaKindSecret, defaultPSMDBSecretName, &secret)
 	if err != nil {
 		return errors.Wrap(err, "cannot get default PSMDB secrets")
 	}

--- a/service/k8sclient/k8sclient_test.go
+++ b/service/k8sclient/k8sclient_test.go
@@ -18,6 +18,7 @@ package k8sclient
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -69,6 +70,18 @@ func TestK8sClient(t *testing.T) {
 		require.NoError(t, err)
 
 		l.Info("XtraDB Cluster is created")
+
+		t.Run("Create cluster with the same name", func(t *testing.T) {
+			err = client.CreateXtraDBCluster(ctx, &XtraDBParams{
+				Name:             name,
+				Size:             1,
+				PXC:              &PXC{DiskSize: "1000000000"},
+				ProxySQL:         &ProxySQL{DiskSize: "1000000000"},
+				PMMPublicAddress: pmmPublicAddress,
+			})
+			require.Error(t, err)
+			assert.Equal(t, err.Error(), fmt.Sprintf(clusterWithSameNameExistsErrTemplate, name))
+		})
 
 		assertListXtraDBCluster(ctx, t, client, name, func(cluster *XtraDBCluster) bool {
 			return cluster != nil && cluster.State == ClusterStateReady
@@ -135,6 +148,17 @@ func TestK8sClient(t *testing.T) {
 		require.NoError(t, err)
 
 		l.Info("PSMDB Cluster is created")
+
+		t.Run("Create cluster with the same name", func(t *testing.T) {
+			err = client.CreatePSMDBCluster(ctx, &PSMDBParams{
+				Name:             name,
+				Size:             1,
+				Replicaset:       &Replicaset{DiskSize: "1000000000"},
+				PMMPublicAddress: pmmPublicAddress,
+			})
+			require.Error(t, err)
+			assert.Equal(t, err.Error(), fmt.Sprintf(clusterWithSameNameExistsErrTemplate, name))
+		})
 
 		assertListPSMDBCluster(ctx, t, client, name, func(cluster *PSMDBCluster) bool {
 			return cluster != nil && cluster.State == ClusterStateReady


### PR DESCRIPTION
We display an error when user tries to create a db cluster with the
name of existing cluster.

It is allowed to have two clusters with the same name only if they are
of different type - MySQL, MongoDB.