### PR TITLE
PMM-8725 Add paused state, pxc operator introduced it in 1.9.0

### DIFF
--- a/service/cluster/xtra_db_cluster.go
+++ b/service/cluster/xtra_db_cluster.go
@@ -142,8 +142,12 @@ func (s *XtraDBClusterService) ListXtraDBClusters(ctx context.Context, req *cont
 			Exposed: cluster.Exposed,
 		}
 
-		if cluster.State == k8sclient.ClusterStateReady && cluster.Pause {
-			res.Clusters[i].State = controllerv1beta1.XtraDBClusterState_XTRA_DB_CLUSTER_STATE_PAUSED
+		if cluster.State == k8sclient.ClusterStatePaused {
+			if cluster.Pause {
+				res.Clusters[i].State = controllerv1beta1.XtraDBClusterState_XTRA_DB_CLUSTER_STATE_PAUSED
+			} else {
+				res.Clusters[i].State = controllerv1beta1.XtraDBClusterState_XTRA_DB_CLUSTER_STATE_CHANGING
+			}
 		}
 	}
 

--- a/service/k8sclient/internal/pxc/pxc_types.go
+++ b/service/k8sclient/internal/pxc/pxc_types.go
@@ -83,6 +83,8 @@ const (
 	AppStateReady AppState = "ready"
 	// AppStateError error state.
 	AppStateError AppState = "error"
+	// AppStatePaused means cluster is paused.
+	AppStatePaused AppState = "paused"
 )
 
 // PerconaXtraDBClusterStatus defines the observed state of PerconaXtraDBCluster.

--- a/service/k8sclient/k8sclient.go
+++ b/service/k8sclient/k8sclient.go
@@ -66,7 +66,7 @@ const (
 	ClusterStateReady ClusterState = 3
 	// ClusterStateDeleting represents a cluster which are in deleting state (deleting).
 	ClusterStateDeleting ClusterState = 4
-	// ClusterStatePaused represents a paused cluster state (status.state.ready and spec.pause.true).
+	// ClusterStatePaused represents a paused cluster state.
 	ClusterStatePaused ClusterState = 5
 )
 
@@ -297,6 +297,7 @@ var pxcStatesMap = map[pxc.AppState]ClusterState{ //nolint:gochecknoglobals
 	pxc.AppStateInit:    ClusterStateChanging,
 	pxc.AppStateReady:   ClusterStateReady,
 	pxc.AppStateError:   ClusterStateFailed,
+	pxc.AppStatePaused:  ClusterStatePaused,
 }
 
 // psmdbStatesMap matches psmdb app states to cluster states.


### PR DESCRIPTION
PXC operator added state `paused` in latest release, old way of detecting paused cluster stopped working.
Now, we take `paused` state into account.