### PR TITLE
PMM-8836 Use latest operators from version service instead of hardcoded ones

### DIFF
--- a/service/k8sclient/k8sclient_test.go
+++ b/service/k8sclient/k8sclient_test.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -121,8 +122,8 @@ func (c *VersionServiceClient) Matrix(ctx context.Context, params componentsPara
 	if params.productVersion != "" {
 		paths = append(paths, params.productVersion)
 	}
-	url := strings.Join(paths, "/")
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	url := path.Join(paths...)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (c *VersionServiceClient) Matrix(ctx context.Context, params componentsPara
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("failed to close response body: %v", err)
 		}
 	}()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -172,7 +173,10 @@ func (c *VersionServiceClient) LatestOperatorVersion(ctx context.Context, pmmVer
 		return nil, nil, err
 	}
 	latestPXCOperator, err := latest(pmmVersionDeps.Matrix.PXCOperator)
-	return latestPXCOperator, latestPSMDBOperator, err
+	if err != nil {
+		return nil, nil, err
+	}
+	return latestPXCOperator, latestPSMDBOperator, nil
 }
 
 const (

--- a/service/k8sclient/k8sclient_test.go
+++ b/service/k8sclient/k8sclient_test.go
@@ -61,28 +61,11 @@ func NewVersionServiceClient(url string) *VersionServiceClient {
 type componentsParams struct {
 	product        string
 	productVersion string
-	dbVersion      string
-}
-
-// componentVersion contains info about exact component version.
-type componentVersion struct {
-	ImagePath string `json:"imagePath"`
-	ImageHash string `json:"imageHash"`
-	Status    string `json:"status"`
-	Critical  bool   `json:"critical"`
 }
 
 type matrix struct {
-	Mongod        map[string]componentVersion `json:"mongod"`
-	Pxc           map[string]componentVersion `json:"pxc"`
-	Pmm           map[string]componentVersion `json:"pmm"`
-	Proxysql      map[string]componentVersion `json:"proxysql"`
-	Haproxy       map[string]componentVersion `json:"haproxy"`
-	Backup        map[string]componentVersion `json:"backup"`
-	Operator      map[string]componentVersion `json:"operator"`
-	LogCollector  map[string]componentVersion `json:"logCollector"`
-	PXCOperator   map[string]componentVersion `json:"pxcOperator,omitempty"`
-	PSMDBOperator map[string]componentVersion `json:"psmdbOperator,omitempty"`
+	PXCOperator   map[string]interface{} `json:"pxcOperator,omitempty"`
+	PSMDBOperator map[string]interface{} `json:"psmdbOperator,omitempty"`
 }
 
 type Version struct {
@@ -98,7 +81,7 @@ type VersionServiceResponse struct {
 
 var errNoVersionsFound error = errors.New("no versions to compare current version with found")
 
-func latest(m map[string]componentVersion) (*goversion.Version, error) {
+func latest(m map[string]interface{}) (*goversion.Version, error) {
 	if len(m) == 0 {
 		return nil, errNoVersionsFound
 	}
@@ -137,9 +120,6 @@ func (c *VersionServiceClient) Matrix(ctx context.Context, params componentsPara
 	paths := []string{c.url, params.product}
 	if params.productVersion != "" {
 		paths = append(paths, params.productVersion)
-		if params.dbVersion != "" {
-			paths = append(paths, params.dbVersion)
-		}
 	}
 	url := strings.Join(paths, "/")
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/service/k8sclient/k8sclient_test.go
+++ b/service/k8sclient/k8sclient_test.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -118,12 +119,16 @@ func latestProduct(s []Version) (*goversion.Version, error) {
 
 // Matrix calls version service with given params and returns components matrix.
 func (c *VersionServiceClient) Matrix(ctx context.Context, params componentsParams) (*VersionServiceResponse, error) {
-	paths := []string{c.url, params.product}
+	baseURL, err := url.Parse(c.url)
+	if err != nil {
+		return nil, err
+	}
+	paths := []string{baseURL.Path, params.product}
 	if params.productVersion != "" {
 		paths = append(paths, params.productVersion)
 	}
-	url := path.Join(paths...)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	baseURL.Path = path.Join(paths...)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service/k8sclient/k8sclient_test.go
+++ b/service/k8sclient/k8sclient_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -95,7 +96,7 @@ type VersionServiceResponse struct {
 	Versions []Version `json:"versions"`
 }
 
-var errNoVersionsFound = errors.New("no versions to compare current version with found")
+var errNoVersionsFound error = errors.New("no versions to compare current version with found")
 
 func latest(m map[string]componentVersion) (*goversion.Version, error) {
 	if len(m) == 0 {
@@ -149,7 +150,12 @@ func (c *VersionServiceClient) Matrix(ctx context.Context, params componentsPara
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I forgot to change tests when upgrade of operators feature was implemented.

I copy&pasted code from pmm-managed as it was the easiest way to bring version service into dbaas-controller.
It does not feel like a good solutions though.
@BupycHuk @oter would you recommend importing code from pmm-managed? I does not feel like good solution either.