### PR TITLE
PMM-10040 Relabel metrics from cadvisor

### DIFF
--- a/deploy/victoriametrics/crs/vmnodescrape.yaml
+++ b/deploy/victoriametrics/crs/vmnodescrape.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   scheme: "https"
   interval: "10s"
+  honorLabels: true
   scrapeTimeout: "2s"
   selector: {}
   tlsConfig:
@@ -20,3 +21,10 @@ spec:
       regex: (.+)
       targetLabel: __metrics_path__
       replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+  metricRelabelConfigs:
+  - source_labels:
+    - namespace
+    - pod
+    target_label: node_name
+    regex: (.+);(.+)
+    replacement: $1-$2


### PR DESCRIPTION
[PMM-10040](https://jira.percona.com/browse/PMM-10040)

Add new label "node_name" for grouping metrics from node_exporter and metrics from k8s cluster in dashboards.

Build: [SUBMODULES](https://github.com/Percona-Lab/pmm-submodules/pull/2540)
