### PR TITLE
PMM-10640 Added missing fields for the request.

### DIFF
--- a/service/k8sclient/k8sclient.go
+++ b/service/k8sclient/k8sclient.go
@@ -1932,7 +1932,9 @@ func (c *K8sClient) getPSMDBSpec(params *PSMDBParams, extra extraCRParams) *psmd
 					Port: 27017,
 				},
 				OperationProfiling: &psmdb.MongodSpecOperationProfiling{
-					Mode: psmdb.OperationProfilingModeSlowOp,
+					Mode:              psmdb.OperationProfilingModeSlowOp,
+					SlowOpThresholdMs: 100,
+					RateLimit:         100,
 				},
 				Security: &psmdb.MongodSpecSecurity{
 					RedactClientLogData:  false,


### PR DESCRIPTION
There is an error in MongoDB 5 prior to 5.0.6 in where if the rate limit and the slow op threshold are not specified, the docker container won't start.

https://jira.percona.com/browse/PMM-10640
Build: https://github.com/Percona-Lab/pmm-submodules/pull/2772


