### PR TITLE
Discord links have been removed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,4 +171,4 @@ For more efficient review process we use a mixed approach:
 
 Once your pull request is merged, you are an official Percona Community Contributor. Welcome to the community!
 
-We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com) and [Discord](https://discord.gg/mQEyGPkNbR).
+We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We encourage contributions and are always looking for new members that are as de
 
 If you’re looking for information about how you can contribute, we have [contribution guidelines](CONTRIBUTING.md) across all our repositories in `CONTRIBUTING.md` files. Some of them may just link to the main project’s repository’s contribution guidelines.
 
-We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com) and [Discord](https://per.co.na/discord).
+We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com).
 
 ## Submitting Bug Reports
 


### PR DESCRIPTION
The Community Team is closing the Discord channel and for this reason I have removed the links to the channel.